### PR TITLE
chore: remove unnecessary version management

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,6 @@
     <google.core.version>1.92.2</google.core.version>
     <google.api-common.version>1.8.1</google.api-common.version>
     <google.common-protos.version>1.17.0</google.common-protos.version>
-    <google.auth.version>0.19.0</google.auth.version>
     <gax.version>1.53.0</gax.version>
     <grpc.version>1.26.0</grpc.version>
     <protobuf.version>3.11.1</protobuf.version>

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,6 @@
     <google.api-common.version>1.8.1</google.api-common.version>
     <google.common-protos.version>1.17.0</google.common-protos.version>
     <google.auth.version>0.19.0</google.auth.version>
-    <google.http-client.version>1.34.0</google.http-client.version>
     <gax.version>1.53.0</gax.version>
     <grpc.version>1.26.0</grpc.version>
     <protobuf.version>3.11.1</protobuf.version>
@@ -129,13 +128,6 @@
         <groupId>com.google.auth</groupId>
         <artifactId>google-auth-library-bom</artifactId>
         <version>${google.auth.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-      <dependency>
-        <groupId>com.google.http-client</groupId>
-        <artifactId>google-http-client-bom</artifactId>
-        <version>${google.http-client.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -124,13 +124,6 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
-      <dependency>
-        <groupId>com.google.auth</groupId>
-        <artifactId>google-auth-library-bom</artifactId>
-        <version>${google.auth.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
 
       <dependency>
         <groupId>com.google.protobuf</groupId>
@@ -274,7 +267,6 @@
           <links>
             <link>https://grpc.io/grpc-java/javadoc/</link>
             <link>https://developers.google.com/protocol-buffers/docs/reference/java/</link>
-            <link>https://googleapis.dev/java/google-auth-library/latest/</link>
             <link>https://googleapis.dev/java/gax/latest/</link>
             <link>https://googleapis.github.io/api-common-java/${google.api-common.version}/apidocs/</link>
           </links>


### PR DESCRIPTION
Both `google-http-client` and `google-auth-library` are not declared dependencies so there's no need to version manage them.