### PR TITLE
chore: add enumeration data type to .repo-metadata.json

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -11,6 +11,6 @@
     "repo_short": "java-billingbudgets",
     "distribution_name": "com.google.cloud:google-cloud-billingbudgets",
     "api_id": "billingbudgets.googleapis.com",
-    "transport": "grpc",
-    "requires_billing": true
+    "requires_billing": true,
+    "library_type": "GAPIC_AUTO"
 }


### PR DESCRIPTION
Adds a standard enumeration of library types in .repo-metadata.json